### PR TITLE
added support for binary content (trailing newline after null byte is optional now) 

### DIFF
--- a/stompest/async.py
+++ b/stompest/async.py
@@ -15,8 +15,8 @@ Copyright 2011 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import logging
 import sys
+import logging
 
 import stomper
 
@@ -120,7 +120,7 @@ class StompClient(LineOnlyReceiver):
                 break
             try:
                 command = self.cmdMap[message['cmd']]
-            except:
+            except KeyError:
                 raise StompFrameError('Unknown STOMP command: %s' % message)
             command(message)
             

--- a/stompest/async.py
+++ b/stompest/async.py
@@ -17,24 +17,24 @@ Copyright 2011 Mozes, Inc.
 """
 import sys
 import logging
+
 import stomper
 
-from twisted.python import usage, log
 from twisted.internet import reactor, defer
 from twisted.protocols.basic import LineOnlyReceiver
 from twisted.internet.protocol import ClientFactory
 from twisted.internet.error import ConnectionLost
 
-from stompest.parser import StompFrameLineParser
+from stompest.parser import StompParser
 from stompest.error import StompError, StompProtocolError, StompConnectTimeout, StompFrameError
 from stompest.util import cloneStompMessageForErrorDest
 
-LOG_CATEGORY="stompest.async"
+LOG_CATEGORY = 'stompest.async'
 
 class StompClient(LineOnlyReceiver):
     """A Twisted implementation of a STOMP client"""
     MAX_LENGTH = sys.maxint
-    delimiter = StompFrameLineParser.FRAME_DELIMITER
+    delimiter = StompParser.FRAME_DELIMITER
 
     def __init__(self):
         self.log = logging.getLogger(LOG_CATEGORY)
@@ -75,31 +75,31 @@ class StompClient(LineOnlyReceiver):
             
         #Remove connect timeout if set
         if self.connectTimeoutDelayedCall is not None:
-            self.log.debug("Cancelling connect timeout after TCP connection was lost")
+            self.log.debug('Cancelling connect timeout after TCP connection was lost')
             self.connectTimeoutDelayedCall.cancel()
             self.connectTimeoutDelayedCall = None
         
         #Callback for failed connect
         if self.connectedDeferred:
             if self.connectError:
-                self.log.debug("Calling connectedDeferred errback: %s" % self.connectError)
+                self.log.debug('Calling connectedDeferred errback: %s' % self.connectError)
                 self.connectedDeferred.errback(self.connectError)
                 self.connectError = None
             else:
-                self.log.error("Connection lost with outstanding connectedDeferred")
-                error = StompError("Unexpected connection loss")
-                self.log.debug("Calling connectedDeferred errback: %s" % error)
+                self.log.error('Connection lost with outstanding connectedDeferred')
+                error = StompError('Unexpected connection loss')
+                self.log.debug('Calling connectedDeferred errback: %s' % error)
                 self.connectedDeferred.errback(error)                
             self.connectedDeferred = None
         
         #Callback for disconnect
         if self.disconnectedDeferred:
             if self.disconnectError:
-                #self.log.debug("Calling disconnectedDeferred errback: %s" % self.disconnectError)
+                #self.log.debug('Calling disconnectedDeferred errback: %s' % self.disconnectError)
                 self.disconnectedDeferred.errback(self.disconnectError)
                 self.disconnectError = None
             else:
-                #self.log.debug("Calling disconnectedDeferred callback")
+                #self.log.debug('Calling disconnectedDeferred callback')
                 self.disconnectedDeferred.callback(self)
             self.disconnectedDeferred = None
             
@@ -109,22 +109,22 @@ class StompClient(LineOnlyReceiver):
         """When a line is received, process it and dispatch when we've
            got a whole frame
         """
-        # self.log.debug("Received line [%s]" % line)
+        # self.log.debug('Received line [%s]' % line)
         # the delimiter was left off by LineOnlyReceiver, so add it back in
-        line = line + self.delimiter
+        self.parser.add(line + self.delimiter)
         
-        for l in line.lstrip('\n').split('\n'):
-            self.parser.processLine(l)
-            if self.parser.isDone():
-                frame = self.parser.getMessage()
-                self.resetParser()
-                if frame['cmd'] in self.cmdMap:
-                    self.cmdMap[frame['cmd']](frame)
-                else:
-                    raise StompFrameError("Unknown STOMP command: %s" % str(frame))
-
+        while True:
+            message = self.parser.getMessage()
+            if not message:
+                break
+            try:
+                command = self.cmdMap[message['cmd']]
+            except:
+                raise StompFrameError('Unknown STOMP command: %s' % message)
+            command(message)
+            
     def lineLengthExceeded(self, line):
-        errorMsg = "Stomp protocol implementation line length maximum (%s) was exceeded" % self.MAX_LENGTH
+        errorMsg = 'Stomp protocol implementation line length maximum (%s) was exceeded' % self.MAX_LENGTH
         self.log.critical(errorMsg)
         raise Exception(errorMsg)
 
@@ -134,24 +134,24 @@ class StompClient(LineOnlyReceiver):
     def _connect(self):
         """Send connect command
         """
-        self.log.debug("Sending connect command")
+        self.log.debug('Sending connect command')
         cmd = stomper.connect(self.factory.login, self.factory.passcode)
-        # self.log.debug("Writing cmd: %s" % cmd)
+        # self.log.debug('Writing cmd: %s' % cmd)
         self.transport.write(cmd)
 
     def _disconnect(self):
         """Send disconnect command
         """
-        self.log.debug("Sending disconnect command")
+        self.log.debug('Sending disconnect command')
         cmd = stomper.disconnect()
-        # self.log.debug("Writing cmd: %s" % cmd)
+        # self.log.debug('Writing cmd: %s' % cmd)
         self.transport.write(cmd)
 
     def _subscribe(self, dest, headers):
         """Send subscribe command
         """
         ack = headers.get('ack', None)
-        self.log.debug("Sending subscribe command for destination %s with ack mode %s" % (dest, ack))
+        self.log.debug('Sending subscribe command for destination %s with ack mode %s' % (dest, ack))
 
         headers['destination'] = dest
                 
@@ -159,15 +159,15 @@ class StompClient(LineOnlyReceiver):
         frame.cmd = 'SUBSCRIBE'
         frame.headers = headers
         cmd = frame.pack()
-        # self.log.debug("Writing cmd: %s" % cmd)
+        # self.log.debug('Writing cmd: %s' % cmd)
         self.transport.write(cmd)
 
     def _ack(self, messageId):
         """Send ack command
         """
-        self.log.debug("Sending ack command for message: %s" % messageId)
+        self.log.debug('Sending ack command for message: %s' % messageId)
         cmd = stomper.ack(messageId)
-        # self.log.debug("Writing cmd: %s" % cmd)
+        # self.log.debug('Writing cmd: %s' % cmd)
         self.transport.write(cmd)
 
     #
@@ -176,7 +176,7 @@ class StompClient(LineOnlyReceiver):
     def resetParser(self):
         """Stomp parser must be reset after each frame is received
         """
-        self.parser = StompFrameLineParser()
+        self.parser = StompParser()
     
     def finishHandlers(self):
         """Return a Deferred to signal when all requests in process are complete
@@ -192,16 +192,16 @@ class StompClient(LineOnlyReceiver):
     
     def handlerFinished(self, messageId):
         del self.activeHandlers[messageId]
-        self.log.debug("Handler complete for message: %s" % messageId)
+        self.log.debug('Handler complete for message: %s' % messageId)
 
     def handlerStarted(self, messageId):
         if messageId in self.activeHandlers:
             raise StompProtocolError('Duplicate message received. Message id %s is already in progress' % messageId)
         self.activeHandlers[messageId] = None
-        self.log.debug("Handler started for message: %s" % messageId)
+        self.log.debug('Handler started for message: %s' % messageId)
     
     def messageHandlerFailed(self, failure, messageId, msg, errDest):
-        self.log.error("Error in message handler: %s" % str(failure))
+        self.log.error('Error in message handler: %s' % str(failure))
         disconnect = False
         #Forward message to error queue if configured
         if errDest is not None:
@@ -221,19 +221,19 @@ class StompClient(LineOnlyReceiver):
         return None
         
     def connectTimeout(self, timeout):
-        self.log.error("Connect command timed out after %s seconds" % timeout)
+        self.log.error('Connect command timed out after %s seconds' % timeout)
         self.connectTimeoutDelayedCall = None
-        self.connectError = StompConnectTimeout("Connect command timed out after %s seconds" % timeout)
+        self.connectError = StompConnectTimeout('Connect command timed out after %s seconds' % timeout)
         self.transport.loseConnection()
         
     def handleConnected(self, msg):
         """Handle STOMP CONNECTED commands
         """
         sessionId = msg['headers'].get('session', None)
-        self.log.debug("Connected to stomp broker with session: %s" % sessionId)
+        self.log.debug('Connected to stomp broker with session: %s' % sessionId)
         #Remove connect timeout if set
         if self.connectTimeoutDelayedCall is not None:
-            self.log.debug("Cancelling connect timeout after sucessfully connecting")
+            self.log.debug('Cancelling connect timeout after sucessfully connecting')
             self.connectTimeoutDelayedCall.cancel()
             self.connectTimeoutDelayedCall = None
         self.disconnectedDeferred = defer.Deferred()
@@ -250,11 +250,11 @@ class StompClient(LineOnlyReceiver):
 
         #Do not process any more messages if we're disconnecting
         if self.disconnecting:
-            self.log.debug("Disconnecting...ignoring stomp message: %s at destination: %s" % (messageId, dest))
+            self.log.debug('Disconnecting...ignoring stomp message: %s at destination: %s' % (messageId, dest))
             return
 
         if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("Received stomp message %s from destination %s: [%s...].  Headers: %s" % (messageId, dest, msg['body'][:20], msg['headers']))
+            self.log.debug('Received stomp message %s from destination %s: [%s...].  Headers: %s' % (messageId, dest, msg['body'][:20], msg['headers']))
         
         #Call message handler (can return deferred to be async)
         self.handlerStarted(messageId)        
@@ -275,24 +275,24 @@ class StompClient(LineOnlyReceiver):
     def handleError(self, msg):
         """Handle STOMP ERROR commands
         """
-        self.log.info("Received stomp error: %s" % msg)
+        self.log.info('Received stomp error: %s' % msg)
         if self.connectedDeferred is not None:
             self.transport.loseConnection()
-            self.connectError = StompProtocolError("STOMP error message received while trying to connect: %s" % msg)
+            self.connectError = StompProtocolError('STOMP error message received while trying to connect: %s' % msg)
         else:
             #Work around for AMQ < 5.2
             if 'message' in msg['headers'] and msg['headers']['message'].find('Unexpected ACK received for message-id') >= 0:
                 self.log.debug('AMQ brokers < 5.2 do not support client-individual mode.')
             else:
                 #Set disconnect error
-                self.disconnectError = StompProtocolError("STOMP error message received: %s" % msg)
+                self.disconnectError = StompProtocolError('STOMP error message received: %s' % msg)
                 #Disconnect
                 self.disconnect()
         
     def handleReceipt(self, msg):
         """Handle STOMP RECEIPT commands
         """
-        self.log.info("Received stomp receipt: %s" % msg)
+        self.log.info('Received stomp receipt: %s' % msg)
     
     #
     # Public functions
@@ -316,35 +316,36 @@ class StompClient(LineOnlyReceiver):
 
         return self.disconnectedDeferred
     
-    def subscribe(self, dest, handler, headers={}, **kwargs):
+    def subscribe(self, dest, handler, headers=None, **kwargs):
         """Subscribe to a destination and register a function handler to receive messages for that destination
         """
         errorDestination = kwargs.get('errorDestination', None)
         # client-individual mode is only supported in AMQ >= 5.2
         # headers['ack'] = headers.get('ack', 'client-individual')
+        headers = headers or {}
         headers['ack'] = headers.get('ack', 'client')
         self.destMap[dest] = {'handler': handler, 'ack': headers['ack'], 'errorDestination': errorDestination}
         self._subscribe(dest, headers)
     
-    def send(self, dest, msg, headers={}):
+    def send(self, dest, msg, headers=None):
         """Do the send command to enqueue a message to a destination
         """
+        headers = headers or {}
         if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("Sending message to %s: [%s...]" % (dest, msg[:20]))
+            self.log.debug('Sending message to %s: [%s...]' % (dest, msg[:20]))
         frame = stomper.Frame()
         frame.cmd = 'SEND'
         frame.headers = headers
         frame.headers['destination'] = dest
         frame.body = msg
         cmd = frame.pack()
-        # self.log.debug("Writing cmd: %s" % cmd)
+        # self.log.debug('Writing cmd: %s' % cmd)
         self.transport.write(cmd)
         
     def getDisconnectedDeferred(self):
         return self.disconnectedDeferred
     
 class StompClientFactory(ClientFactory):
-
     protocol = StompClient
 
     def __init__(self, **kwargs):
@@ -355,19 +356,18 @@ class StompClientFactory(ClientFactory):
         self.log = logging.getLogger(LOG_CATEGORY)
     
     def buildProtocol(self, addr):
-        p = ClientFactory.buildProtocol(self, addr)
+        protocol = ClientFactory.buildProtocol(self, addr)
         #This is a sneaky way of passing the protocol instance back to the caller
-        reactor.callLater(0, self.buildProtocolDeferred.callback, p)
-        return p
+        reactor.callLater(0, self.buildProtocolDeferred.callback, protocol)
+        return protocol
     
     def clientConnectionFailed(self, connector, reason):
         """Connection failed
         """
-        self.log.error("Connection failed. Reason: %s" % str(reason))
+        self.log.error('Connection failed. Reason: %s' % str(reason))
         self.buildProtocolDeferred.errback(reason)
 
 class StompConfig(object):
-
     def __init__(self, host, port, **kwargs):
         self.host = host
         self.port = port
@@ -376,7 +376,6 @@ class StompConfig(object):
         self.log = logging.getLogger(LOG_CATEGORY)
 
 class StompCreator(object):
-
     def __init__(self, config, **kwargs):
         self.config = config
         self.connectTimeout = kwargs.get('connectTimeout', None)

--- a/stompest/parser.py
+++ b/stompest/parser.py
@@ -33,6 +33,7 @@ class StompParser(object):
             'body': self._parseBody,
         }
         self._messages = collections.deque()
+        self._flush()
         self._next()
         
     def getMessage(self):

--- a/stompest/parser.py
+++ b/stompest/parser.py
@@ -64,7 +64,7 @@ class StompParser(object):
         if not command:
             return
         if command not in stomper.VALID_COMMANDS:
-            raise StompFrameError('Invalid command: %s' % command)
+            raise StompFrameError('Invalid command: %s' % repr(command))
         self._message['cmd'] = command
         self._transition('headers')
         

--- a/stompest/parser.py
+++ b/stompest/parser.py
@@ -85,8 +85,6 @@ class StompParser(object):
             headers[name] = value
             self._transition('headers')
         else:
-            if not headers:
-                raise StompFrameError('No headers found')
             self._length = int(self._message['headers'].get(self.CONTENT_LENGTH_HEADER, -1))
             self._transition('body')
         

--- a/stompest/parser.py
+++ b/stompest/parser.py
@@ -13,87 +13,82 @@ Copyright 2011 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
+import collections
+import cStringIO
+
+import stomper
 from stompest.error import StompFrameError
 
-class StompFrameLineParser(object):
-    """State machine for line-based parsing of STOMP frames.
-    
-    http://stomp.codehaus.org/Protocol
-    
-    Note: Although the protocol allows for null bytes in the body
-          in conjunction with the content-length header, it is not
-          implemented
-    
-    parser = StompFrameLineParser()
-    frame = None
-    while 1:
-        line = getNextLine()
-        parser.processLine(line)
-          if parser.isDone():
-              frame = parser.getMessage()
-              break
-    """
+class StompParser(object):
     LINE_DELIMITER = '\n'
     FRAME_DELIMITER = '\x00'
-    HEADER_DELIMITER = ':'
-
-    def __init__(self):
-        self.message = dict(cmd='', headers={}, body='')
-        self.state = 'cmd'
-        self.done = False
-        self.states = {
-            'cmd': self.parseCommandLine,
-            'headers': self.parseHeaderLine,
-            'body': self.parseBodyLine,
-        }
+    HEADER_SEPARATOR = ':'
     
-    def isDone(self):
-        """Call this method after each line is processed to see if the frame is complete
-        """
-        return self.done
+    CONTENT_LENGTH_HEADER = 'content-length'
+    
+    def __init__(self):
+        self._states = {
+            'cmd': self._parseCommand,
+            'headers': self._parseHeader,
+            'body': self._parseBody,
+        }
+        self._messages = collections.deque()
+        self._next()
         
     def getMessage(self):
-        """When a complete frame has been parsed, call this method to get whole thing
-        """
-        if (self.done):
-            return self.message
-        return None
+        if self._messages:
+            return self._messages.popleft()
     
-    def processLine(self, line):
-        """Call this method for each line receive for the stomp frame
-        """
-        if (self.done):
-            raise StompFrameError('processLine() called after frame end')
-        self.states[self.state](line)
+    def add(self, data):
+        for character in data: 
+            self._states[self._state](character)
+    
+    def _flush(self):
+        self._buffer = cStringIO.StringIO()
 
-    #
-    # Internal methods
-    #
-    def transition(self, newState):
-        self.state = newState
+    def _next(self):
+        self._message = {'cmd': '', 'headers': {}, 'body': ''}
+        self._length = -1
+        self._read = 0
+        self._transition('cmd')
     
-    def parseCommandLine(self, line):
-        if (len(line) == 0):
-            raise StompFrameError("Empty stomp command line: %s" % line)
-        self.message['cmd'] = line
-        self.transition('headers')
+    def _transition(self, newState):
+        self._flush()
+        self._state = newState
         
-    def parseHeaderLine(self, line):
-        if (len(line) == 0):
-            self.transition('body')
+    def _parseCommand(self, character):
+        if character != self.LINE_DELIMITER:
+            self._buffer.write(character)
             return
-        try:
-            name, value = line.split(self.HEADER_DELIMITER, 1)
-        except ValueError:
-            raise StompFrameError('Invalid stomp header line: [%s], len [%d]' % (line, len(line)))
-        self.message['headers'][name] = value
-        
-    def parseBodyLine(self, line):
-        if line.endswith(self.FRAME_DELIMITER):
-            self.message['body'] += line[:-1]
-            self.endFrame()
+        command = self._buffer.getvalue()
+        if not command:
             return
-        self.message['body'] += line + self.LINE_DELIMITER
+        if command not in stomper.VALID_COMMANDS:
+            raise StompFrameError('Invalid command: %s' % command)
+        self._message['cmd'] = command
+        self._transition('headers')
         
-    def endFrame(self):
-        self.done = True
+    def _parseHeader(self, character):
+        if character != self.LINE_DELIMITER:
+            self._buffer.write(character)
+            return
+        header = self._buffer.getvalue()
+        if header:
+            try:
+                name, value = header.split(self.HEADER_SEPARATOR, 1)
+            except ValueError:
+                raise StompFrameError('No separator in header line: %s' % header)
+            self._message['headers'][name] = value
+            self._transition('headers')
+        else:
+            self._length = int(self._message['headers'].get(self.CONTENT_LENGTH_HEADER, -1))
+            self._transition('body')
+        
+    def _parseBody(self, character):
+        self._read += 1
+        if (self._read <= self._length) or (character != self.FRAME_DELIMITER):
+            self._buffer.write(character)
+            return
+        self._message['body'] = self._buffer.getvalue()
+        self._messages.append(self._message)
+        self._next()

--- a/stompest/simple.py
+++ b/stompest/simple.py
@@ -21,9 +21,9 @@ import stomper
 
 from stompest.error import StompProtocolError
 from stompest.parser import StompParser
-from stompest.util import createFrame
+from stompest.util import createFrame as _createFrame
 
-LOG_CATEGORY="stompest.simple"
+LOG_CATEGORY = 'stompest.simple'
 
 class Stomp(object):
     """A simple implementation of a STOMP client"""
@@ -54,20 +54,18 @@ class Stomp(object):
             readList, _, _ = select.select([self.socket], [], [])
         else:
             readList, _, _ = select.select([self.socket], [], [], timeout)
-        return len(readList) > 0
+        return bool(readList)
         
     def send(self, dest, msg, headers=None):
         headers = headers or {}
+        headers['destination'] = dest
         frame = {'cmd': 'SEND', 'headers': headers, 'body': msg}
-        frame['headers']['destination'] = dest
         self.sendFrame(frame)
         
     def subscribe(self, dest, headers=None):
         headers = headers or {}
-        if 'ack' not in headers:
-            headers['ack'] = 'auto'
-        if not 'activemq.prefetchSize' in headers:
-            headers['activemq.prefetchSize'] = 1
+        headers.setdefault('ack', 'auto')
+        headers.setdefault('activemq.prefetchSize', 1)
         headers['destination'] = dest
         self.sendFrame({'cmd': 'SUBSCRIBE', 'headers': headers, 'body': ''})
         
@@ -89,7 +87,7 @@ class Stomp(object):
             self.parser.add(data)
     
     def packFrame(self, message):
-        return createFrame(message).pack()
+        return _createFrame(message).pack()
         
     def _setParser(self):
         self.parser = StompParser()

--- a/stompest/simple.py
+++ b/stompest/simple.py
@@ -80,11 +80,7 @@ class Stomp(object):
     
     def receiveFrame(self):
         while True:
-            try:
-                message = self.parser.getMessage()
-            except:
-                print self.parser.__dict__
-                raise
+            message = self.parser.getMessage()
             if message:
                 return message
             data = self.socket.recv(4096)

--- a/stompest/simple.py
+++ b/stompest/simple.py
@@ -28,6 +28,8 @@ LOG_CATEGORY = 'stompest.simple'
 class Stomp(object):
     """A simple implementation of a STOMP client"""
     
+    READ_SIZE = 4096
+    
     def __init__(self, host, port):
         self.log = logging.getLogger(LOG_CATEGORY)
         self.host = host
@@ -78,10 +80,15 @@ class Stomp(object):
     
     def receiveFrame(self):
         while True:
-            message = self.parser.getMessage()
+            try:
+                message = self.parser.getMessage()
+            except Exception, e:
+                self.log.exception(e)
+                self.log.error('Parser state: %s' % self.parser.__dict__)
+                raise
             if message:
                 return message
-            data = self.socket.recv(4096)
+            data = self.socket.recv(self.READ_SIZE)
             if not data:
                 raise Exception('Connection closed')
             self.parser.add(data)

--- a/stompest/tests/async_stomp_client_integration_test.py
+++ b/stompest/tests/async_stomp_client_integration_test.py
@@ -181,7 +181,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
         #Client disconnected and returned error
         try:
             yield stomp.getDisconnectedDeferred()
-        except StompestTestError, e:
+        except StompestTestError:
             pass
         else:
             self.assertTrue(False)
@@ -237,7 +237,7 @@ class GracefulDisconnectTestCase(unittest.TestCase):
         #Connect
         stomp = yield creator.getConnection()
         
-        for i in range(self.numMsgs):
+        for _ in range(self.numMsgs):
             stomp.send(self.queue, self.msg)
         stomp.subscribe(self.queue, self._msgHandler, {'ack': self.ackMode, 'activemq.prefetchSize': self.numMsgs})
         

--- a/stompest/tests/async_stomp_client_integration_test.py
+++ b/stompest/tests/async_stomp_client_integration_test.py
@@ -14,14 +14,18 @@ Copyright 2011 Mozes, Inc.
    limitations under the License.
 """
 import logging
+
 import stomper
 from twisted.trial import unittest
+
 from stompest.simple import Stomp
-from stompest.async import StompConfig, StompCreator, StompClient
-from stompest.error import StompError
-from twisted.internet import error, reactor, defer
+from stompest.async import StompConfig, StompCreator
+from twisted.internet import reactor, defer
 
 logging.basicConfig(level=logging.DEBUG)
+
+HOST = 'localhost'
+PORT = 61613
 
 class StompestTestError(Exception):
     pass
@@ -35,7 +39,7 @@ def getClientAckMode():
 def supportsClientIndividual():
     supported = False
     queue = '/queue/testClientAckMode'
-    stomp = Stomp('localhost', 61613)
+    stomp = Stomp(HOST, PORT)
     stomp.connect()
     stomp.send(queue, 'test')
     stomp.subscribe(queue, {'ack': 'client-individual'})
@@ -64,7 +68,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
         self.cleanQueue(self.errorQueue)
     
     def cleanQueue(self, queue):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         stomp.connect()
         stomp.subscribe(queue, {'ack': 'client'})
         while stomp.canRead(1):
@@ -83,7 +87,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
     def test_onhandlerException_ackMessage_filterReservedHdrs_send2ErrorQ_and_disconnect(self):
         self.cleanQueues()
         
-        config = StompConfig('localhost', 61613)
+        config = StompConfig(HOST, PORT)
         creator = StompCreator(config, alwaysDisconnectOnUnhandledMsg=True)
         
         #Connect
@@ -100,7 +104,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
         #Client disconnected and returned error
         try:
             yield stomp.getDisconnectedDeferred()
-        except StompestTestError, e:
+        except StompestTestError:
             pass
         else:
             self.assertTrue(False)
@@ -131,7 +135,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
     def test_onhandlerException_ackMessage_filterReservedHdrs_send2ErrorQ_and_no_disconnect(self):
         self.cleanQueues()
         
-        config = StompConfig('localhost', 61613)
+        config = StompConfig(HOST, PORT)
         creator = StompCreator(config)
         
         #Connect
@@ -162,7 +166,7 @@ class HandlerExceptionWithErrorQueueIntegrationTestCase(unittest.TestCase):
     def test_onhandlerException_disconnect(self):
         self.cleanQueues()
         
-        config = StompConfig('localhost', 61613)
+        config = StompConfig(HOST, PORT)
         creator = StompCreator(config)
         
         #Connect
@@ -224,10 +228,10 @@ class GracefulDisconnectTestCase(unittest.TestCase):
     
     @defer.inlineCallbacks
     def test_onDisconnect_waitForOutstandingMessagesToFinish(self):
-        self.config = StompConfig('localhost', 61613)
+        self.config = StompConfig(HOST, PORT)
         self.creator = StompCreator(self.config)
         
-        config = StompConfig('localhost', 61613)
+        config = StompConfig(HOST, PORT)
         creator = StompCreator(config)
         
         #Connect

--- a/stompest/tests/async_stomp_client_test.py
+++ b/stompest/tests/async_stomp_client_test.py
@@ -54,7 +54,6 @@ class AsyncStompClientTestCase(unittest.TestCase):
         stomp.cmdMap[frame['cmd']] = mock.Mock()
         
         self.assertTrue(frameBytes.endswith('\x00\n'))
-        
         for line in frameBytes.split('\x00'):
             stomp.lineReceived(line)
                 

--- a/stompest/tests/async_stomp_client_test.py
+++ b/stompest/tests/async_stomp_client_test.py
@@ -16,13 +16,16 @@ Copyright 2011 Mozes, Inc.
 import logging
 
 import stomper
+import mock
+import binascii
 from twisted.internet import error, reactor, defer
 from twisted.internet.protocol import Factory 
 from twisted.python import log
 from twisted.trial import unittest
 
-from stompest.async import StompConfig, StompCreator
-from stompest.error import StompProtocolError, StompConnectTimeout
+from stompest.util import createFrame
+from stompest.async import StompConfig, StompCreator, StompClient
+from stompest.error import StompProtocolError, StompConnectTimeout, StompFrameError
 from stompest.tests.broker_simulator import BlackHoleStompServer, ErrorOnConnectStompServer, ErrorOnSendStompServer
 
 observer = log.PythonLoggingObserver()
@@ -40,13 +43,58 @@ class AsyncStompClientTestCase(unittest.TestCase):
         config = StompConfig('localhost', 65535)
         creator = StompCreator(config)
         return self.assertFailure(creator.getConnection(), error.ConnectionRefusedError)
-          
-    def feedDataToStomp(self, stomp, data):
-        for line in data.split('\n')[:-1]:
+        
+    def test_lineReceived(self):
+        hdrs = {'foo': '1'}
+        body = 'blah'
+        frame = {'cmd': 'MESSAGE', 'headers': hdrs, 'body': body}
+        frameBytes = createFrame(frame).pack() 
+        
+        stomp = StompClient()
+        stomp.cmdMap[frame['cmd']] = mock.Mock()
+        
+        self.assertTrue(frameBytes.endswith('\x00\n'))
+        
+        for line in frameBytes.split('\x00'):
             stomp.lineReceived(line)
-    
-    def getFrame(self, cmd, headers, body):
-        return StompParser.packFrame(cmd, headers, body)
+                
+        self.assertEquals(1, stomp.cmdMap[frame['cmd']].call_count)
+        stomp.cmdMap[frame['cmd']].assert_called_with({'cmd': frame['cmd'], 'headers': hdrs, 'body': body})
+        
+        for line in frameBytes.split('\x00'):
+            stomp.lineReceived(line)
+
+        self.assertEquals(2, stomp.cmdMap[frame['cmd']].call_count)
+        stomp.cmdMap[frame['cmd']].assert_called_with({'cmd': frame['cmd'], 'headers': hdrs, 'body': body})
+        
+    def test_lineReceived_binary(self):
+        body = binascii.a2b_hex('f0000a09')
+        hdrs = {'foo': '1', 'content-length': str(len(body))}
+        frame = {'cmd': 'MESSAGE', 'headers': hdrs, 'body': body}
+        frameBytes = createFrame(frame).pack() 
+        
+        stomp = StompClient()
+        stomp.cmdMap[frame['cmd']] = mock.Mock()
+        
+        self.assertTrue(frameBytes.endswith('\x00\n'))
+        
+        for line in frameBytes.split('\x00'):
+            stomp.lineReceived(line)
+        
+        self.assertEquals(1, stomp.cmdMap[frame['cmd']].call_count)
+        stomp.cmdMap[frame['cmd']].assert_called_with({'cmd': frame['cmd'], 'headers': hdrs, 'body': body})
+        
+    def test_lineReceived_unexpected_exception(self):
+        class MyError(Exception):
+            pass
+        
+        stomp = StompClient()
+        stomp.cmdMap['DISCONNECT'] = mock.Mock(side_effect=MyError)
+        
+        self.assertRaises(MyError, stomp.lineReceived, stomper.disconnect())
+
+    def test_lineReceived_bad_command(self):
+        self.assertRaises(StompFrameError, StompClient().lineReceived, 'BAD_CMD\n\n\x00\n')
 
 class AsyncClientBaseTestCase(unittest.TestCase):
     protocol = None

--- a/stompest/tests/async_stomp_client_test.py
+++ b/stompest/tests/async_stomp_client_test.py
@@ -14,14 +14,16 @@ Copyright 2011 Mozes, Inc.
    limitations under the License.
 """
 import logging
+
 import stomper
-from twisted.trial import unittest
-from stompest.async import StompConfig, StompCreator, StompClient
-from stompest.error import StompProtocolError, StompConnectTimeout
-from stompest.tests.broker_simulator import BlackHoleStompServer, ErrorOnConnectStompServer, ErrorOnSendStompServer
 from twisted.internet import error, reactor, defer
 from twisted.internet.protocol import Factory 
 from twisted.python import log
+from twisted.trial import unittest
+
+from stompest.async import StompConfig, StompCreator
+from stompest.error import StompProtocolError, StompConnectTimeout
+from stompest.tests.broker_simulator import BlackHoleStompServer, ErrorOnConnectStompServer, ErrorOnSendStompServer
 
 observer = log.PythonLoggingObserver()
 observer.start()
@@ -44,11 +46,7 @@ class AsyncStompClientTestCase(unittest.TestCase):
             stomp.lineReceived(line)
     
     def getFrame(self, cmd, headers, body):
-        sFrame = stomper.Frame()
-        sFrame.cmd = cmd
-        sFrame.headers = headers
-        sFrame.body = body
-        return sFrame.pack()
+        return StompParser.packFrame(cmd, headers, body)
 
 class AsyncClientBaseTestCase(unittest.TestCase):
     protocol = None

--- a/stompest/tests/async_stomp_client_test.py
+++ b/stompest/tests/async_stomp_client_test.py
@@ -13,11 +13,11 @@ Copyright 2011 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
+import binascii
 import logging
 
-import stomper
 import mock
-import binascii
+import stomper
 from twisted.internet import error, reactor, defer
 from twisted.internet.protocol import Factory 
 from twisted.python import log

--- a/stompest/tests/broker_simulator.py
+++ b/stompest/tests/broker_simulator.py
@@ -26,6 +26,8 @@ from stompest.error import StompError
 LOG_CATEGORY = 'stompest.tests.broker_simulator'
 
 class BlackHoleStompServer(LineOnlyReceiver):
+    delimiter = StompParser.FRAME_DELIMITER
+    
     def __init__(self):
         self.log = logging.getLogger(LOG_CATEGORY)
         self.resetParser()
@@ -46,7 +48,7 @@ class BlackHoleStompServer(LineOnlyReceiver):
             self.factory.disconnectDeferred.callback('Disconnected')
 
     def lineReceived(self, line):
-        self.parser.add(line + self.parser.LINE_DELIMITER)
+        self.parser.add(line + self.delimiter)
         message = self.parser.getMessage()
         if not message:
             return
@@ -58,7 +60,6 @@ class BlackHoleStompServer(LineOnlyReceiver):
 
     def resetParser(self):
         self.parser = StompParser()
-        self.delimiter = self.parser.LINE_DELIMITER
 
     def getFrame(self, cmd, headers, body):
         sFrame = stomper.Frame()

--- a/stompest/tests/simple_stomp_test.py
+++ b/stompest/tests/simple_stomp_test.py
@@ -13,29 +13,96 @@ Copyright 2011 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
+import binascii
 import unittest
-from mock import Mock
 
+from mock import Mock
 import stomper
-from stompest.simple import Stomp
+
 from stompest.error import StompProtocolError
+from stompest.simple import Stomp
+from stompest.parser import StompParser
+from stompest.util import createFrame
+
+HOST = '10.241.220.91'
+PORT = 61613
 
 class SimpleStompTest(unittest.TestCase):
+    def _gen_bytes(self, bytes_):
+        for byte in bytes_:
+            yield byte
+        while True:
+            yield ''
+        
+    def _recv(self, iterator, size):
+        result = []
+        for _ in range(size):
+            result.append(iterator.next())
+        return ''.join(result)
+            
+    def _get_receive_mock(self, bytes_):
+        stomp = Stomp(HOST, PORT)
+        stomp._checkConnected = Mock()
+        stomp.socket = Mock()
+        bIter = self._gen_bytes(bytes_).__iter__()
+        stomp.socket.recv = Mock(wraps=lambda size, *args: self._recv(bIter, size))
+        return stomp
+        
+    def test_receiveFrame(self):
+        hdrs = {'x': 'y'}
+        body = 'testing 1 2 3'
+        frameBytes = self.getFrame('MESSAGE', hdrs, body)
+        self.assertTrue(frameBytes.endswith('\x00\n'))
+        
+        stomp = self._get_receive_mock(frameBytes)
+        frame = stomp.receiveFrame()
+        self.assertEquals('MESSAGE', frame['cmd'])
+        self.assertEquals(hdrs, frame['headers'])
+        self.assertEquals(body, frame['body'])
+        
+        self.assertEquals(1, stomp.socket.recv.call_count)
+
+    def test_receiveFrame_no_newline(self):
+        hdrs = {'x': 'y'}
+        body = 'testing 1 2 3'
+        frameBytes = self.getFrame('MESSAGE', hdrs, body)[:-1]
+        self.assertTrue(frameBytes.endswith('\x00'))
+        
+        stomp = self._get_receive_mock(frameBytes)
+        frame = stomp.receiveFrame()
+        self.assertEquals('MESSAGE', frame['cmd'])
+        self.assertEquals(hdrs, frame['headers'])
+        self.assertEquals(body, frame['body'])
+        
+        self.assertEquals(1, stomp.socket.recv.call_count)
+
+    def test_receiveFrame_binary(self):
+        body = binascii.a2b_hex('f0000a09')
+        hdrs = {'content-length': str(len(body))}
+        frameBytes = self.getFrame('MESSAGE', hdrs, body)
+        
+        stomp = self._get_receive_mock(frameBytes)
+        frame = stomp.receiveFrame()
+        self.assertEquals('MESSAGE', frame['cmd'])
+        self.assertEquals(hdrs, frame['headers'])
+        self.assertEquals(body, frame['body'])
+        
+        self.assertEquals(1, stomp.socket.recv.call_count)
     
     def test_canRead_raises_exception_before_connect(self):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         self.assertRaises(Exception, lambda: stomp.canRead())
 
     def test_send_raises_exception_before_connect(self):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         self.assertRaises(Exception, lambda: stomp.send('/queue/foo', 'test message'))
 
     def test_subscribe_raises_exception_before_connect(self):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         self.assertRaises(Exception, lambda: stomp.subscribe('/queue/foo'))
     
     def test_disconnect_raises_exception_before_connect(self):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         self.assertRaises(Exception, lambda: stomp.disconnect())
     
     def test_connect_raises_exception_for_bad_host(self):
@@ -43,7 +110,7 @@ class SimpleStompTest(unittest.TestCase):
         self.assertRaises(Exception, lambda: stomp.connect())
 
     def test_error_frame_after_connect_raises_StompProtocolError(self):
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         stomp._socketConnect = Mock()
         stomp.receiveFrame = Mock()
         stomp.receiveFrame.return_value = {'cmd': 'ERROR', 'headers': {}, 'body': 'fake error'}
@@ -54,82 +121,68 @@ class SimpleStompTest(unittest.TestCase):
     def test_connect_writes_correct_frame(self):
         login = 'curious'
         passcode = 'george'
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         stomp._socketConnect = Mock()
         stomp.receiveFrame = Mock()
         stomp.receiveFrame.return_value = {'cmd': 'CONNECTED', 'headers': {}, 'body': ''}
         stomp.socket = Mock()
         stomp.connect(login=login,passcode=passcode)
-        args,kargs = stomp.socket.sendall.call_args
+        args, _ = stomp.socket.sendall.call_args
         sentFrame = self.parseFrame(args[0])
-        self.assertEquals({'cmd': 'CONNECT',
-                           'headers': {'login': login,
-                                       'passcode': passcode,
-                                      },
-                           'body': ''}, sentFrame)
+        self.assertEquals({
+           'cmd': 'CONNECT',
+           'headers': {'login': login, 'passcode': passcode},
+           'body': ''
+        }, sentFrame)
     
     def test_send_writes_correct_frame(self):
         dest = '/queue/foo'
         msg = 'test message'
         headers = {'foo': 'bar', 'fuzz': 'ball'}
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         stomp._checkConnected = Mock()
         stomp._write = Mock()
         stomp.send(dest, msg, headers)
-        args,kargs = stomp._write.call_args
+        args, _ = stomp._write.call_args
         sentFrame = self.parseFrame(args[0])
-        self.assertEquals({'cmd': 'SEND',
-                           'headers': {'destination': dest,
-                                       'foo': 'bar',
-                                       'fuzz': 'ball',
-                                      },
-                           'body': msg}, sentFrame)
+        self.assertEquals({
+           'cmd': 'SEND',
+           'headers': {'destination': dest, 'foo': 'bar', 'fuzz': 'ball'},
+           'body': msg
+        }, sentFrame)
 
     def test_subscribe_writes_correct_frame(self):
         dest = '/queue/foo'
         headers = {'foo': 'bar', 'fuzz': 'ball'}
-        stomp = Stomp('localhost', 61613)
+        stomp = Stomp(HOST, PORT)
         stomp._checkConnected = Mock()
         stomp._write = Mock()
         stomp.subscribe(dest, headers)
-        args,kargs = stomp._write.call_args
+        args, _ = stomp._write.call_args
         sentFrame = self.parseFrame(args[0])
-        self.assertEquals({'cmd': 'SUBSCRIBE',
-                           'headers': {'destination': dest,
-                                       'ack': 'auto',
-                                       'activemq.prefetchSize': '1',
-                                       'foo': 'bar',
-                                       'fuzz': 'ball',
-                                      },
-                           'body': ''}, sentFrame)
+        self.assertEquals({
+            'cmd': 'SUBSCRIBE',
+            'headers': {'destination': dest, 'ack': 'auto', 'activemq.prefetchSize': '1', 'foo': 'bar', 'fuzz': 'ball'},
+            'body': ''
+        }, sentFrame)
 
     def test_ack_writes_correct_frame(self):
-        id = '12345'
-        stomp = Stomp('localhost', 61613)
+        id_ = '12345'
+        stomp = Stomp(HOST, PORT)
         stomp._checkConnected = Mock()
         stomp._write = Mock()
-        stomp.ack({'cmd': 'MESSAGE', 'headers': {'message-id': id}, 'body': 'blah'})
-        args,kargs = stomp._write.call_args
+        stomp.ack({'cmd': 'MESSAGE', 'headers': {'message-id': id_}, 'body': 'blah'})
+        args, _ = stomp._write.call_args
         sentFrame = self.parseFrame(args[0])
-        self.assertEquals({'cmd': 'ACK',
-                           'headers': {'message-id': id,
-                                      },
-                           'body': ''}, sentFrame)
+        self.assertEquals({'cmd': 'ACK', 'headers': {'message-id': id_}, 'body': ''}, sentFrame)
 
     def parseFrame(self, message):
-        from stompest.parser import StompFrameLineParser
-        parser = StompFrameLineParser()        
-        for line in message.split('\n')[:-1]:
-            parser.processLine(line)
-        self.assertTrue(parser.isDone())
+        parser = StompParser()        
+        parser.add(message)
         return parser.getMessage()
 
     def getFrame(self, cmd, headers, body):
-        sFrame = stomper.Frame()
-        sFrame.cmd = cmd
-        sFrame.headers = headers
-        sFrame.body = body
-        return sFrame.pack()
+        return createFrame({'cmd': cmd, 'headers': headers, 'body': body}).pack()
         
 if __name__ == '__main__':
     unittest.main()

--- a/stompest/tests/simple_stomp_test.py
+++ b/stompest/tests/simple_stomp_test.py
@@ -24,7 +24,7 @@ from stompest.simple import Stomp
 from stompest.parser import StompParser
 from stompest.util import createFrame
 
-HOST = '10.241.220.91'
+HOST = 'fakeHost'
 PORT = 61613
 
 class SimpleStompTest(unittest.TestCase):
@@ -87,6 +87,24 @@ class SimpleStompTest(unittest.TestCase):
         self.assertEquals(hdrs, frame['headers'])
         self.assertEquals(body, frame['body'])
         
+        self.assertEquals(1, stomp.socket.recv.call_count)
+        
+    def test_receiveFrame_multiple_frames_per_read(self):
+        body1 = 'boo'
+        body2 = 'hoo'
+        frameBytes = self.getFrame('MESSAGE', {}, body1)[:-1] + self.getFrame('MESSAGE', {}, body2)
+        stomp = self._get_receive_mock(frameBytes)
+        
+        #Read first frame
+        frame = stomp.receiveFrame()
+        self.assertEquals('MESSAGE', frame['cmd'])
+        self.assertEquals(body1, frame['body'])
+        self.assertEquals(1, stomp.socket.recv.call_count)
+
+        #Read next frame
+        frame = stomp.receiveFrame()
+        self.assertEquals('MESSAGE', frame['cmd'])
+        self.assertEquals(body2, frame['body'])
         self.assertEquals(1, stomp.socket.recv.call_count)
     
     def test_canRead_raises_exception_before_connect(self):

--- a/stompest/tests/stomp_parser_test.py
+++ b/stompest/tests/stomp_parser_test.py
@@ -28,10 +28,14 @@ class StompParserTest(unittest.TestCase):
             'body': 'some stuff\nand more'
         }
         frame = createFrame(message)
-        cmd = frame.pack()[:-1] # remove optional trailing newline which stomper adds to frames
-        
         parser = StompParser()
-        parser.add(cmd)
+        
+        parser.add(frame.pack())
+        self.assertEqual(parser.getMessage(), {'cmd': frame.cmd, 'headers': frame.headers, 'body': frame.body})
+        self.assertEqual(parser.getMessage(), None)
+        
+        #This time remove optional trailing newline which stomper adds to frames
+        parser.add(frame.pack()[:-1])
         self.assertEqual(parser.getMessage(), {'cmd': frame.cmd, 'headers': frame.headers, 'body': frame.body})
         self.assertEqual(parser.getMessage(), None)
         

--- a/stompest/tests/util_test.py
+++ b/stompest/tests/util_test.py
@@ -17,7 +17,6 @@ import unittest
 from stompest.util import filterReservedHeaders
 
 class UtilTest(unittest.TestCase):
-    
     def test_filterReservedHeaders(self):
         origHdrs = {'message-id': 'delete me', 'timestamp': 'delete me too', 'foo': 'bar'}
         filteredHdrs = filterReservedHeaders(origHdrs)

--- a/stompest/util.py
+++ b/stompest/util.py
@@ -38,6 +38,6 @@ def cloneStompMessageForErrorDest(msg):
 def createFrame(message):
     frame = Frame()
     frame.cmd = message['cmd']
-    frame.headers = message['headers']
-    frame.body = message['body']
+    frame.headers = message.get('headers', {})
+    frame.body = message.get('body', '')
     return frame

--- a/stompest/util.py
+++ b/stompest/util.py
@@ -18,6 +18,8 @@ Copyright 2011 Mozes, Inc.
 """
 from copy import deepcopy
 
+from stomper import Frame
+
 reservedHeaders = ['message-id', 'timestamp', 'expires', 'priority', 'destination']
 
 def filterReservedHeaders(headers):
@@ -33,4 +35,9 @@ def cloneStompMessageForErrorDest(msg):
     errMsg['headers']['persistent'] = 'true'
     return errMsg
 
-    
+def createFrame(message):
+    frame = Frame()
+    frame.cmd = message['cmd']
+    frame.headers = message['headers']
+    frame.body = message['body']
+    return frame


### PR DESCRIPTION
- replaced StompFrameLineParser (line-oriented) by StompParser (stream-oriented). I decided against stomper.stompbuffer.StompBuffer because I found it too involved and decided to write a parser from scratch. I do not think that there is any need for StompFrameLineParser because the stream-based version is more general. I'll try and port StompParser over to stomper as a next step.
- updated test cases
- removed dangerous mutable default arguments like def f(headers={}): by def f(headers=None):
